### PR TITLE
Add KV cache support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -26,6 +26,12 @@ const graphQLOptions = {
   //   allowOrigin: '*',
   //   allowMethods: 'GET, POST, PUT',
   // },
+
+  // Enable KV caching for external REST data source requests
+  // Note that you'll need to add a KV namespace called
+  // WORKERS_GRAPHQL_CACHE in your wrangler.toml file for this to
+  // work! See the project README for more information.
+  enableKvCache: false
 }
 
 const handleRequest = request => {

--- a/src/kv-cache.js
+++ b/src/kv-cache.js
@@ -1,0 +1,16 @@
+class KVCache {
+  get(key) {
+    return WORKERS_GRAPHQL_CACHE.get(key)
+  }
+
+  set(key, value, options) {
+    const opts = {}
+    const ttl = options && options.ttl
+    if (ttl) {
+      opts.expirationTtl = ttl
+    }
+    return WORKERS_GRAPHQL_CACHE.put(key, value, opts)
+  }
+}
+
+module.exports = KVCache


### PR DESCRIPTION
Adds a KV cache at `WORKERS_GRAPHQL_CACHE` to cache any outgoing REST requests via a [`apollo-server-caching`](https://www.npmjs.com/package/apollo-server-caching) implementation. The config option is opt-in, but #11 will cover documentation for this before release