### PR TITLE
Fix: CORS headers not being applied to requests

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -58,6 +58,14 @@ const graphQLServerOptions: GraphQLServerOptions = {
 
 const app = new Hono<{ Bindings: Bindings }>()
 
+if (graphQLServerOptions.cors) {
+  if (typeof graphQLServerOptions.cors === 'boolean') {
+    app.use(cors())
+  } else {
+    app.use(cors(graphQLServerOptions.cors))
+  }
+}
+
 app.all(graphQLServerOptions.baseEndpoint, (context) => {
   return Apollo(context, graphQLServerOptions)
 })
@@ -68,14 +76,6 @@ app.all('*', async (c) => {
   }
   return new Response('Not found', { status: 404 })
 })
-
-if (graphQLServerOptions.cors) {
-  if (typeof graphQLServerOptions.cors === 'boolean') {
-    app.use(cors())
-  } else {
-    app.use(cors(graphQLServerOptions.cors))
-  }
-}
 
 app.onError((err, c) => {
   console.error(err)


### PR DESCRIPTION
_Copied from https://github.com/cloudflare/workers-graphql-server/pull/60, which I accidentally deleted 😅:_

This PR fixes an issue where CORS headers were not being applied, due to the wrong order (routes before middleware).

I came across this issue when I tried to fetch the GraphQL endpoint from React.

<img width="416" height="127" alt="452617220-92cbf20d-f6d8-4748-8718-77f705537a1e" src="https://github.com/user-attachments/assets/e091fc5d-380a-42e7-a0c0-9929ce3c4ac2" />

By moving the middleware above the routes, [as it is done in the Hono documentation](https://hono.dev/docs/guides/middleware#execution-order), we ensure they are applied to all requests.